### PR TITLE
Updated to work w/ OTP-24+

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PROJECT = pbkdf2
 PROJECT_DESCRIPTION = Erlang PBKDF2 Key Derivation Function
-PROJECT_VERSION = 1.0.1
+PROJECT_VERSION = 1.0.2
 
 LOCAL_DEPS = crypto
 

--- a/ebin/pbkdf2.app
+++ b/ebin/pbkdf2.app
@@ -1,6 +1,6 @@
 {application, pbkdf2, [
 	{description, "Erlang PBKDF2 Key Derivation Function"},
-	{vsn, "1.0.0"},
+	{vsn, "1.0.1"},
 	{modules, ['pbkdf2']},
 	{registered, []},
 	{applications, [kernel,stdlib,crypto]}

--- a/src/pbkdf2.erl
+++ b/src/pbkdf2.erl
@@ -15,7 +15,6 @@
 -export([pbkdf2/4, pbkdf2/5, compare_secure/2, to_hex/1]).
 
 
-%-type(hex_char() :: $0 .. $9 | $a .. $f).
 -type(hex_char() :: 48 .. 57 | 97 .. 102).
 -type(hex_list() :: [hex_char()]).
 
@@ -114,10 +113,9 @@ pbkdf2(MacFunc, Password, Salt, Iterations, BlockIndex, Iteration, Prev, Acc) ->
 
 resolve_mac_func({hmac, DigestFunc}) ->
 	fun(Key, Data) ->
-		%crypto:hmac(DigestFunc, Key, Data)
-		HMAC = crypto:hmac_init(DigestFunc, Key),
-		HMAC1 = crypto:hmac_update(HMAC, Data),
-		crypto:hmac_final(HMAC1)
+		HMAC = crypto:mac_init(hmac, DigestFunc, Key),
+		HMAC1 = crypto:mac_update(HMAC, Data),
+		crypto:mac_final(HMAC1)
 	end;
 
 resolve_mac_func(MacFunc) when is_function(MacFunc) ->


### PR DESCRIPTION
`crypto:hmac_*/*` no longer exist. Updated to use the new `crypto:mac_*/*` instead.